### PR TITLE
Example .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# Auto-generated directories
+dev-tools/phpdoc-tmp/
+docs/
+vendor/
+
+# Auto-generated files
+composer.lock
+test.sqlite


### PR DESCRIPTION
A basic .gitignore file so 'git status' does not show auto-generated files and directories.